### PR TITLE
Series Tokens Fix in Certain Places

### DIFF
--- a/orgSeries-utility.php
+++ b/orgSeries-utility.php
@@ -97,9 +97,9 @@ function token_replace($replace, $referral = 'other', $id = 0, $ser_ID = 0) {
 	}
 		
 	if( stristr($replace, '%series_icon%') ) 
-	$replace = str_replace('%series_icon%', get_series_icon('fit_width=' .  $ser_width . '&link=0&series=' . $id . '&display=0'), $replace);
+	$replace = str_replace('%series_icon%', get_series_icon('fit_width=' .  $ser_width . '&link=0&series=' . $ser_id . '&display=0'), $replace);
 	if( stristr($replace, '%series_icon_linked%') ) 
-	$replace = str_replace('%series_icon_linked%', get_series_icon('fit_width= ' . $ser_width . '&series=' . $id . '&display=0'), $replace);
+	$replace = str_replace('%series_icon_linked%', get_series_icon('fit_width= ' . $ser_width . '&series=' . $ser_id . '&display=0'), $replace);
 	if( stristr($replace, '%series_title%') ) 
 	$replace = str_replace('%series_title%', the_series_title($ser_id, FALSE), $replace);
 	if( stristr($replace, '%series_title_linked%') ) 
@@ -113,7 +113,7 @@ function token_replace($replace, $referral = 'other', $id = 0, $ser_ID = 0) {
 	if( stristr($replace, '%series_part%') ) 
 	$replace = str_replace('%series_part%', wp_series_part($p_id, $ser_id), $replace);
 	if( stristr($replace, '%series_description%') ) 
-	$replace = str_replace('%series_description%', series_description($id), $replace);
+	$replace = str_replace('%series_description%', series_description($ser_id), $replace);
 	if( stristr($replace, '%next_post%') ) 
 	$replace = str_replace('%next_post%', wp_series_nav($id), $replace);
 	if( stristr($replace, '%previous_post%') ) 


### PR DESCRIPTION
The %series_icon%, %series_icon_linked%, and %series_description% tokens were not interpolating correctly in the "Series Meta" and "Series Meta (with excerpts)" sections, due to the post ID instead of the series ID getting passed to token_replace().
