### PR TITLE
removed display of series navigation on a static frontpage

### DIFF
--- a/orgSeries-setup.php
+++ b/orgSeries-setup.php
@@ -470,6 +470,10 @@ class orgSeries {
 	
 	//add series post-list box to a post in that series (on single.php view)
 	function add_series_post_list_box($content) {
+
+		if ( is_front_page() )
+			return $content;
+
 		if ($this->settings['auto_tag_toggle']) {
 			if ( ( is_single() || is_page() ) && $postlist = wp_postlist_display() ) {
 				$addcontent = $content;
@@ -481,6 +485,10 @@ class orgSeries {
 	
 	//add series meta information to posts that belong to a series.
 	function add_series_meta($content) {
+
+                if ( is_front_page() )
+                        return $content;
+
 		if($this->settings['auto_tag_seriesmeta_toggle']) {
 			if ($series_meta = wp_seriesmeta_write()) {
 				$addcontent = $content;
@@ -496,6 +504,7 @@ class orgSeries {
 	}
 	
 	function add_series_meta_excerpt($content) {
+
 		if ( is_single() ) return;
 		if($this->settings['auto_tag_seriesmeta_toggle']) {
 			if ($series_meta = wp_seriesmeta_write(true)) {
@@ -508,6 +517,10 @@ class orgSeries {
 	
 	//add series navigation strip to posts that are part of a series (on single.php view)
 	function series_nav_filter($content) {
+
+                if ( is_front_page() )
+                        return $content;
+
 		if (is_single() || is_page() ) {
 			if($this->settings['auto_tag_nav_toggle'] && $series_nav = wp_assemble_series_nav() ) {
 				$addcontent = $content;


### PR DESCRIPTION
When the WordPress instance is configured to use a page as static frontpage and the page shows a post listing the series navigation was shown (due to `is_single()` returning true). I added a check for `is_front_page()` to prevent this behavior.

(This time with a proper diff)
