### PR TITLE
improve targeting of css selector

### DIFF
--- a/orgSeries-admin.css
+++ b/orgSeries-admin.css
@@ -119,7 +119,7 @@ input #seriesadd {
     width: 60%;
 }
 
-.template {
+#topic-toc-settings-series-template-core .template {
     width: 100%;
 }
 


### PR DESCRIPTION
This prevents conflicts with other plugins.

fixes #39 

I just fixed the main issue for now.  Loading css only on the page it needs to be loaded on will be a part of the general refactor underway.