### PR TITLE
fix bug with usort 

### DIFF
--- a/orgSeries-admin.php
+++ b/orgSeries-admin.php
@@ -184,9 +184,10 @@ function get_series_list( $default = 0 ) {
 		}
 
 		$unsorted_result = $result;
+        usort( $result, '_usort_series_by_name' );
         $result = apply_filters(
             'get_series_list',
-            usort( $result, '_usort_series_by_name' ),
+            $result,
             $unsorted_result
         );
 


### PR DESCRIPTION
This bug prevented existing (and new) series from showing up in the selector when editing a post.  I think it surfaced with the most recent release.