### PR TITLE
Fix description to remove version requirement info

### DIFF
--- a/orgSeries.php
+++ b/orgSeries.php
@@ -3,7 +3,7 @@
 Plugin Name: Organize Series
 Plugin URI: http://organizeseries.com
 Version: 2.5.12.rc.000
-Description: This plugin adds a number of features to wordpress that enable you to easily write and organize a series of posts and display the series dynamically in your blog. You can associate "icons" or "logos" with the various series. This version of Organize Series Plugin requires at least WordPress 3.4+ and PHP 5.2+ to work.
+Description: This plugin adds a number of features to wordpress that enable you to easily write and organize a series of posts and display the series dynamically in your blog. You can associate "icons" or "logos" with the various series.
 Author: Darren Ethier
 Author URI: http://www.unfoldingneurons.com
 Text Domain: organize-series


### PR DESCRIPTION
Not only is the current description out of date, its also unneeded because that info is provided as a part of the plugin meta in the readme.txt.