### PR TITLE
Fix priority for translation loading

### DIFF
--- a/orgSeries-setup.php
+++ b/orgSeries-setup.php
@@ -27,7 +27,7 @@ class orgSeries {
 
 		//all other actions and filters...
 		add_action('plugins_loaded', array($this, 'add_settings'), 10);
-		add_action('init', array($this, 'register_textdomain'));
+		add_action('init', array($this, 'register_textdomain'), 0);
 		add_action('init', array($this, 'register_taxonomy'),0);
 		add_action('admin_enqueue_scripts', array($this, 'register_scripts'));
 		add_action('init', array($this, 'maybe_fix_upgrade'));


### PR DESCRIPTION
Allows translating the admin menu entry "Manage Series" in the "Posts" menu.