### PR TITLE
Always use short titles when included, even in post list

### DIFF
--- a/orgSeries-template-tags.php
+++ b/orgSeries-template-tags.php
@@ -80,7 +80,7 @@ function get_series_posts( $ser_ID = array(), $referral = false, $display = fals
 
 			if ( in_array( $post_status, array( 'publish', 'private' ) ) ) {
 				if ( 'widget' == $referral )
-					$result .= '<li>' . series_post_title($seriespost['id']) . '</li>';
+					$result .= '<li class="serieslist-current-li">' . series_post_title($seriespost['id'], true, $short_title) . '</li>';
 				else
 					$result .= token_replace(stripslashes($settings['series_post_list_post_template']), 'other', $seriespost['id'], $ser);
 			}

--- a/orgSeries-utility.php
+++ b/orgSeries-utility.php
@@ -122,6 +122,8 @@ function token_replace($replace, $referral = 'other', $id = 0, $ser_ID = 0) {
 	$replace = str_replace('%next_post_custom%', wp_series_nav($id, TRUE, TRUE), $replace);
 	if( stristr($replace, '%previous_post_custom%') )
 	$replace = str_replace('%previous_post_custom%', wp_series_nav($id, FALSE, TRUE), $replace);
+	if( stristr($replace, '%post_title_list_short%') )
+	$replace = str_replace('%post_title_list_short%', get_series_posts($id, TRUE), $replace);
 
 	$replace = apply_filters('post_orgseries_token_replace', $replace, $referral, $id, $p_id, $ser_id);
 	return $replace;


### PR DESCRIPTION
revised orgSeries-template-tags.php to always use the short title if the post has one. Before it was only using it for the post you were currently on, all other post titles in the series list widget would display the post title.

revised orgSeries-utility.php to add a new token for short titles in the series post list template and therefore in the series post list, which was something I saw a lot of people asking for at Wordpress.org