### PR TITLE
Short titles everywhere when included in post meta

### DIFF
--- a/orgSeries-template-tags.php
+++ b/orgSeries-template-tags.php
@@ -80,7 +80,7 @@ function get_series_posts( $ser_ID = array(), $referral = false, $display = fals
 
 			if ( in_array( $post_status, array( 'publish', 'private' ) ) ) {
 				if ( 'widget' == $referral )
-					$result .= '<li>' . series_post_title($seriespost['id']) . '</li>';
+					$result .= '<li class="serieslist-current-li">' . series_post_title($seriespost['id'], true, $short_title) . '</li>';
 				else
 					$result .= token_replace(stripslashes($settings['series_post_list_post_template']), 'other', $seriespost['id'], $ser);
 			}

--- a/orgSeries-template-tags.php
+++ b/orgSeries-template-tags.php
@@ -59,10 +59,14 @@ function get_series_posts( $ser_ID = array(), $referral = false, $display = fals
 		$is_unpub_template = apply_filters('unpublished_post_template', $is_unpub_template);
 
 		$posts_in_series = get_series_order($series_post, 0, $ser, FALSE, $is_unpub_template);
-		if ( 'widget' == $referral ) {
+		if ( 'other' == $referral ) {
 			if ($serieswidg_title != false)
 				$result .= '<h4>' . __( $serieswidg_title, 'organize-series') . '</h4>';
-			$result .= '<ul>';
+		}
+		else{
+			if ($serieswidg_title != false)
+				$result .= '<h4>' . __( $serieswidg_title, 'organize-series') . '</h4>';
+				$result .= '<ul>';
 		}
 
 		foreach($posts_in_series as $seriespost) {
@@ -80,7 +84,7 @@ function get_series_posts( $ser_ID = array(), $referral = false, $display = fals
 
 			if ( in_array( $post_status, array( 'publish', 'private' ) ) ) {
 				if ( 'widget' == $referral )
-					$result .= '<li>' . series_post_title($seriespost['id']) . '</li>';
+					$result .= '<li>' . series_post_title($seriespost['id'], true, $short_title) . '</li>';
 				else
 					$result .= token_replace(stripslashes($settings['series_post_list_post_template']), 'other', $seriespost['id'], $ser);
 			}
@@ -88,7 +92,8 @@ function get_series_posts( $ser_ID = array(), $referral = false, $display = fals
 				$result .= apply_filters('unpublished_post_template', $settings, $seriespost, $ser);
 		}
 
-		if ( 'widget' == $referral ) {
+		if ( 'other' == $referral ) {
+		}else {
 			$result .= '</ul>';
 		}
 	}

--- a/orgSeries-template-tags.php
+++ b/orgSeries-template-tags.php
@@ -80,7 +80,7 @@ function get_series_posts( $ser_ID = array(), $referral = false, $display = fals
 
 			if ( in_array( $post_status, array( 'publish', 'private' ) ) ) {
 				if ( 'widget' == $referral )
-					$result .= '<li class="serieslist-current-li">' . series_post_title($seriespost['id'], true, $short_title) . '</li>';
+					$result .= '<li>' . series_post_title($seriespost['id']) . '</li>';
 				else
 					$result .= token_replace(stripslashes($settings['series_post_list_post_template']), 'other', $seriespost['id'], $ser);
 			}

--- a/orgSeries-utility.php
+++ b/orgSeries-utility.php
@@ -122,6 +122,8 @@ function token_replace($replace, $referral = 'other', $id = 0, $ser_ID = 0) {
 	$replace = str_replace('%next_post_custom%', wp_series_nav($id, TRUE, TRUE), $replace);
 	if( stristr($replace, '%previous_post_custom%') )
 	$replace = str_replace('%previous_post_custom%', wp_series_nav($id, FALSE, TRUE), $replace);
+	if( stristr($replace, '%post_title_list_short%') )
+	$replace = str_replace('%post_title_list_short%', get_series_posts($id, TRUE), $replace);
 
 	$replace = apply_filters('post_orgseries_token_replace', $replace, $referral, $id, $p_id, $ser_id);
 	return $replace;


### PR DESCRIPTION
A bit trickier than I first thought. Treats post-list differently than a widget to keep the <ul>'s correct between the two. I'm not sure why, but conditional checking for 'widget' referral wasn't working when I added an 'else', but swapping to check for 'other' vs 'everything else' did work.

I'm very new so I hope this is alright to do?

I also added a token (%post_title_list_short%) that people had been asking for over at WordPress.org. I too wanted this option for the post-list and not just widgets.