### PR TITLE
revert is_front checks as they are unnecessarily causing issues for people

### DIFF
--- a/orgSeries-setup.php
+++ b/orgSeries-setup.php
@@ -499,10 +499,6 @@ class orgSeries {
 
 	//add series post-list box to a post in that series (on single.php view)
 	function add_series_post_list_box($content) {
-
-		if ( is_front_page() )
-			return $content;
-
 		if ($this->settings['auto_tag_toggle']) {
 			if ( ( is_single() || is_page() ) && $postlist = wp_postlist_display() ) {
 				$addcontent = $content;
@@ -514,10 +510,6 @@ class orgSeries {
 
 	//add series meta information to posts that belong to a series.
 	function add_series_meta($content) {
-
-                if ( is_front_page() )
-                        return $content;
-
 		if($this->settings['auto_tag_seriesmeta_toggle']) {
 			if ($series_meta = wp_seriesmeta_write()) {
 				$addcontent = $content;
@@ -545,10 +537,6 @@ class orgSeries {
 
 	//add series navigation strip to posts that are part of a series (on single.php view)
 	function series_nav_filter($content) {
-
-                if ( is_front_page() )
-                        return $content;
-
 		if (is_single() || is_page() ) {
 			if($this->settings['auto_tag_nav_toggle'] && $series_nav = wp_assemble_series_nav() ) {
 				$addcontent = $content;


### PR DESCRIPTION
This fixes #53

There was quite some delay before I got a chance to look into this.  Here's some observations:

- on the home page (whether set to show a static page or latest posts), then series meta is _not_ added.  This is because of [this commit](https://github.com/roughsmoothengine/organize-series/commit/a8b73c5) from [this pull](https://github.com/roughsmoothengine/organize-series/pull/4)
- archive pages are showing series meta information just fine.
- The above is without any changes to existing code.

So it _appears_ that's what happening here is that users are expecting to see series meta information on the home page of their site but after the change in the above commit this stopped happening. In hindsight, I'm not sure why I accepted this commit because:

1. The Series Custom Post Add-on allows for series to be a part of pages, this would complicate things for users with a page a part of a series.
2. It was never really clear _why_ the change was necessary (only _what_ the change would be).
3. The author of the pull can accomplish desired affect by simply de-registering existing filters and adding his own filters with the applied conditions.

So to resolve this issue I decided to revert the changes made in the commit. 

@schneidr I'm just pinging you in this pull so that you are aware.