### PR TITLE
Fix shortcode registration when Series display modules are disabled

### DIFF
--- a/addons/post-details/init.php
+++ b/addons/post-details/init.php
@@ -10,12 +10,6 @@ if (! defined('ABSPATH')) {
 // Always load utilities (needed by settings page)
 require_once __DIR__ . '/includes/class-utilities.php';
 
-// Skip everything else if the Post Details toggle is off
-$pps_pd_opts = get_option('org_series_options', []);
-if (empty($pps_pd_opts['auto_tag_seriesmeta_toggle'])) {
-    return;
-}
-
 require_once __DIR__ . '/post-details.php';
 require_once __DIR__ . '/includes/class-fields.php';
 require_once __DIR__ . '/classes/SeriesPostDetailsRenderer.php';

--- a/addons/post-list-box/init.php
+++ b/addons/post-list-box/init.php
@@ -11,12 +11,6 @@ if (! defined('ABSPATH')) {
 // Always load utilities (needed by settings page)
 require_once __DIR__ . '/includes/class-utilities.php';
 
-// Skip everything else if the Post List Box toggle is off
-$pps_plb_opts = get_option('org_series_options', []);
-if (array_key_exists('auto_tag_toggle', $pps_plb_opts) && empty($pps_plb_opts['auto_tag_toggle'])) {
-    return;
-}
-
 // Load the main Post List Box class
 require_once __DIR__ . '/post-list-box.php';
 

--- a/addons/post-navigation/init.php
+++ b/addons/post-navigation/init.php
@@ -10,12 +10,6 @@ if (! defined('ABSPATH')) {
 // Always load utilities (needed by settings page)
 require_once __DIR__ . '/includes/class-utilities.php';
 
-// Skip everything else if the Navigation toggle is off
-$pps_nav_opts = get_option('org_series_options', []);
-if (empty($pps_nav_opts['auto_tag_nav_toggle'])) {
-    return;
-}
-
 require_once __DIR__ . '/post-navigation.php';
 require_once __DIR__ . '/includes/class-fields.php';
 require_once __DIR__ . '/classes/PostNavigationRenderer.php';

--- a/composer.json
+++ b/composer.json
@@ -28,7 +28,7 @@
     "automattic/vipwpcs": "^2.3",
     "dealerdirect/phpcodesniffer-composer-installer": "^0.7.1",
     "overtrue/phplint": "^9.6",
-    "publishpress/translations": "dev-development"
+    "publishpress/translations": "^1.0"
   },
   "scripts": {
     "build": "build zip",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "2695dde0698059dd61043e8981d7a9c2",
+    "content-hash": "8bda80dfe6c704936b2bc27074e59209",
     "packages": [],
     "packages-dev": [
         {
@@ -346,16 +346,16 @@
         },
         {
             "name": "guzzlehttp/psr7",
-            "version": "2.8.0",
+            "version": "2.9.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/guzzle/psr7.git",
-                "reference": "21dc724a0583619cd1652f673303492272778051"
+                "reference": "7d0ed42f28e42d61352a7a79de682e5e67fec884"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/guzzle/psr7/zipball/21dc724a0583619cd1652f673303492272778051",
-                "reference": "21dc724a0583619cd1652f673303492272778051",
+                "url": "https://api.github.com/repos/guzzle/psr7/zipball/7d0ed42f28e42d61352a7a79de682e5e67fec884",
+                "reference": "7d0ed42f28e42d61352a7a79de682e5e67fec884",
                 "shasum": ""
             },
             "require": {
@@ -371,6 +371,7 @@
             "require-dev": {
                 "bamarni/composer-bin-plugin": "^1.8.2",
                 "http-interop/http-factory-tests": "0.9.0",
+                "jshttp/mime-db": "1.54.0.1",
                 "phpunit/phpunit": "^8.5.44 || ^9.6.25"
             },
             "suggest": {
@@ -442,7 +443,7 @@
             ],
             "support": {
                 "issues": "https://github.com/guzzle/psr7/issues",
-                "source": "https://github.com/guzzle/psr7/tree/2.8.0"
+                "source": "https://github.com/guzzle/psr7/tree/2.9.0"
             },
             "funding": [
                 {
@@ -458,7 +459,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-08-23T21:21:41+00:00"
+            "time": "2026-03-10T16:41:02+00:00"
         },
         {
             "name": "overtrue/phplint",
@@ -910,16 +911,16 @@
         },
         {
             "name": "publishpress/translations",
-            "version": "dev-development",
+            "version": "1.0.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/publishpress/library-publishpress-translator.git",
-                "reference": "6c0550e9bc81bf9943c037361b65593b89aef72d"
+                "reference": "ea40919b8737a17e7dd6453b438854a0e8036278"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/publishpress/library-publishpress-translator/zipball/6c0550e9bc81bf9943c037361b65593b89aef72d",
-                "reference": "6c0550e9bc81bf9943c037361b65593b89aef72d",
+                "url": "https://api.github.com/repos/publishpress/library-publishpress-translator/zipball/ea40919b8737a17e7dd6453b438854a0e8036278",
+                "reference": "ea40919b8737a17e7dd6453b438854a0e8036278",
                 "shasum": ""
             },
             "require": {
@@ -939,7 +940,6 @@
                 "szepeviktor/phpstan-wordpress": "^1.3",
                 "wp-coding-standards/wpcs": "^3"
             },
-            "default-branch": true,
             "bin": [
                 "bin/publishpress-translate"
             ],
@@ -962,9 +962,9 @@
             "description": "AI-powered translation automation for PublishPress plugins using Potomatic",
             "support": {
                 "issues": "https://github.com/publishpress/library-publishpress-translator/issues",
-                "source": "https://github.com/publishpress/library-publishpress-translator/tree/development"
+                "source": "https://github.com/publishpress/library-publishpress-translator/tree/1.0.3"
             },
-            "time": "2026-03-04T07:53:31+00:00"
+            "time": "2026-03-24T12:44:13+00:00"
         },
         {
             "name": "ralouphie/getallheaders",
@@ -2579,9 +2579,7 @@
     ],
     "aliases": [],
     "minimum-stability": "stable",
-    "stability-flags": {
-        "publishpress/translations": 20
-    },
+    "stability-flags": {},
     "prefer-stable": true,
     "prefer-lowest": false,
     "platform": {

--- a/lib/vendor/composer/installed.php
+++ b/lib/vendor/composer/installed.php
@@ -3,7 +3,7 @@
         'name' => '__root__',
         'pretty_version' => 'dev-master',
         'version' => 'dev-master',
-        'reference' => 'ee223b05ec87fd0266d627259603f90d4466985a',
+        'reference' => '8eac5062b0cc9a82d0c77ee61d414cea4d7cfaa4',
         'type' => 'library',
         'install_path' => __DIR__ . '/../../',
         'aliases' => array(),
@@ -13,7 +13,7 @@
         '__root__' => array(
             'pretty_version' => 'dev-master',
             'version' => 'dev-master',
-            'reference' => 'ee223b05ec87fd0266d627259603f90d4466985a',
+            'reference' => '8eac5062b0cc9a82d0c77ee61d414cea4d7cfaa4',
             'type' => 'library',
             'install_path' => __DIR__ . '/../../',
             'aliases' => array(),


### PR DESCRIPTION
## Summary
- remove the early returns in the post list box, post details, and post navigation addon bootstraps so their shortcodes still register when the display toggles are unchecked
- keep the display toggles scoped to automatic frontend insertion instead of disabling manual shortcode usage